### PR TITLE
Fix Export PDF button alignment (#3)

### DIFF
--- a/src/components/scenario-manager.tsx
+++ b/src/components/scenario-manager.tsx
@@ -115,7 +115,7 @@ export default function ScenarioManager({ onLoad, getCurrentInputs }: ScenarioMa
   const activeName = scenarios.find((s) => s.id === activeId)?.name;
 
   return (
-    <div className="flex flex-wrap items-center gap-2 mb-4">
+    <div className="flex flex-wrap items-center gap-2">
       {/* Load dropdown */}
       {scenarios.length > 0 && (
         <div className="relative group">


### PR DESCRIPTION
## Summary

- Removed duplicate `mb-4` class from `ScenarioManager`'s wrapper div in `scenario-manager.tsx`
- The parent toolbar container in `roi-calculator.tsx` already applies `mb-4`, so the inner margin was redundant and caused the PDF Export button to sit lower than the scenario manager buttons

## Plan

**Root cause:** `ScenarioManager` wrapped its content in a `<div class="flex flex-wrap items-center gap-2 mb-4">`. Since the parent flex container also has `mb-4` and uses `items-center`, the extra bottom margin on ScenarioManager's box shifted the PDF button's vertical alignment.

**Fix:** Remove `mb-4` from ScenarioManager's wrapper div (one-line change).

Fixes #3

## Test plan

- [x] All 197 vitest tests pass (`npx vitest run`)
- [x] Visually confirm the Export PDF button aligns with the scenario manager buttons in the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)