### PR TITLE
Add CI pipeline for build, lint, and test checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  ci:
+    name: Build, Lint & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     name: Build, Lint & Test
     runs-on: ubuntu-latest
 
+    env:
+      DATABASE_URL: postgresql://user:pass@localhost/fake?sslmode=require
+      AUTH_SECRET: ci-dummy-secret-not-real
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on PRs to `dev` and `main`
- Runs three checks in sequence: **lint**, **build**, and **test** using Node 20 with npm caching
- Combined with branch protection rules on `dev`, this ensures all code passes CI before merging and deploying to Vercel

## Plan

The approach is to gate merges (and therefore Vercel deployments) rather than managing deployments directly. Vercel's automatic Git integration handles deployment — this workflow ensures only passing code gets merged.

**Workflow steps:**
1. Checkout code
2. Setup Node 20 with npm cache
3. `npm ci` — install dependencies
4. `npm run lint` — ESLint checks
5. `npm run build` — Next.js production build
6. `npm run test` — Vitest suite

## Next steps

To fully enforce this, enable branch protection on `dev` in GitHub repo settings:
- Settings > Branches > Add rule for `dev`
- Check "Require status checks to pass before merging"
- Select the "Build, Lint & Test" check

## Test plan

- [ ] Push a PR and confirm the CI workflow runs successfully
- [ ] Verify lint, build, and test steps all pass in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)