### PR TITLE
Make email sender address configurable per environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ RESEND_API_KEY=re_your_api_key_here
 # App URL — Used for generating links in emails (e.g., password reset)
 # Should match your deployed domain in production.
 APP_URL=http://localhost:3000
+
+# Email From — Sender address for transactional emails
+# Use "onboarding@resend.dev" for local dev (no domain verification needed).
+# Set per Vercel environment (preview, production) with your verified domain.
+EMAIL_FROM=onboarding@resend.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       AUTH_SECRET: ci-dummy-secret-not-real
       RESEND_API_KEY: re_ci_dummy_key_not_real
       APP_URL: http://localhost:3000
+      EMAIL_FROM: onboarding@resend.dev
 
     steps:
       - uses: actions/checkout@v4

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,7 +7,7 @@ export async function sendPasswordResetEmail(email: string, token: string) {
   const resetUrl = `${env.APP_URL}/reset-password?token=${token}`;
 
   await resend.emails.send({
-    from: "Cresora <noreply@cresoracommerce.com>",
+    from: env.EMAIL_FROM,
     to: email,
     subject: "Reset your password",
     html: `

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -10,12 +10,14 @@ describe("env validation", () => {
     vi.stubEnv("AUTH_SECRET", "secret123");
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     vi.stubEnv("APP_URL", "http://localhost:3000");
+    vi.stubEnv("EMAIL_FROM", "onboarding@resend.dev");
 
     const { env } = await import("./env");
     expect(env.DATABASE_URL).toBe("postgresql://test");
     expect(env.AUTH_SECRET).toBe("secret123");
     expect(env.RESEND_API_KEY).toBe("re_test_key");
     expect(env.APP_URL).toBe("http://localhost:3000");
+    expect(env.EMAIL_FROM).toBe("onboarding@resend.dev");
 
     vi.unstubAllEnvs();
   });
@@ -25,6 +27,7 @@ describe("env validation", () => {
     vi.stubEnv("AUTH_SECRET", "secret123");
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     vi.stubEnv("APP_URL", "http://localhost:3000");
+    vi.stubEnv("EMAIL_FROM", "onboarding@resend.dev");
 
     await expect(import("./env")).rejects.toThrow("Missing required environment variable: DATABASE_URL");
 
@@ -36,6 +39,7 @@ describe("env validation", () => {
     vi.stubEnv("AUTH_SECRET", "");
     vi.stubEnv("RESEND_API_KEY", "re_test_key");
     vi.stubEnv("APP_URL", "http://localhost:3000");
+    vi.stubEnv("EMAIL_FROM", "onboarding@resend.dev");
 
     await expect(import("./env")).rejects.toThrow("Missing required environment variable: AUTH_SECRET");
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -14,4 +14,5 @@ export const env = {
   AUTH_SECRET: requireEnv("AUTH_SECRET"),
   RESEND_API_KEY: requireEnv("RESEND_API_KEY"),
   APP_URL: requireEnv("APP_URL"),
+  EMAIL_FROM: requireEnv("EMAIL_FROM"),
 };


### PR DESCRIPTION
## Summary

Replaces the hardcoded `from` address in password reset emails with an `EMAIL_FROM` env var, allowing each Vercel environment to use a different sender.

| Environment | `EMAIL_FROM` |
|-------------|-------------|
| Local dev | `onboarding@resend.dev` |
| Preview | `Cresora <noreply@roic-dev.cresoracommerce.com>` |
| Production | `Cresora <noreply@cresoracommerce.com>` |

## Changes

- `src/lib/env.ts` — added `EMAIL_FROM` to required env vars
- `src/lib/email.ts` — use `env.EMAIL_FROM` instead of hardcoded address
- `.env.example` — documented new var with usage guidance
- `.github/workflows/ci.yml` — added dummy value for CI builds
- `src/lib/env.test.ts` — updated tests for new env var

## Test plan

- [x] All 219 tests pass (`npx vitest run`)
- [ ] Add `EMAIL_FROM=onboarding@resend.dev` to `.env.local`
- [ ] Set `EMAIL_FROM` per environment in Vercel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)