### PR TITLE
Add email verification before dashboard access

### DIFF
--- a/drizzle/0003_mean_loa.sql
+++ b/drizzle/0003_mean_loa.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "email_verification_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"used_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "email_verification_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "email_verification_tokens" ADD CONSTRAINT "email_verification_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,303 @@
+{
+  "id": "3414d50c-8a22-478a-af74-8a98e0737e01",
+  "prevId": "b64ed01a-a9e9-437a-beb4-b68dd440202f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_unique": {
+          "name": "email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scenarios": {
+      "name": "scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scenarios_user_id_users_id_fk": {
+          "name": "scenarios_user_id_users_id_fk",
+          "tableFrom": "scenarios",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773426297034,
       "tag": "0002_purple_hellfire_club",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1773439120239,
+      "tag": "0003_mean_loa",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/auth/resend-verification/route.test.ts
+++ b/src/app/api/auth/resend-verification/route.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAuth = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: () => ({ success: true, remaining: 10 }),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: { id: "id", email: "email", emailVerified: "emailVerified" },
+  emailVerificationTokens: {},
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { POST } from "./route";
+import { db } from "@/db";
+import { sendVerificationEmail } from "@/lib/email";
+
+describe("POST /api/auth/resend-verification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAuth.mockResolvedValue({
+      user: { id: "user-123", email: "test@example.com" },
+    });
+
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([{
+        id: "user-123",
+        email: "test@example.com",
+        emailVerified: null,
+      }]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectChain);
+
+    const insertChain = {
+      values: vi.fn().mockResolvedValue(undefined),
+    };
+    (db.insert as ReturnType<typeof vi.fn>).mockReturnValue(insertChain);
+  });
+
+  it("returns 401 if not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe("Authentication required");
+  });
+
+  it("returns 400 if email is already verified", async () => {
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([{
+        id: "user-123",
+        email: "test@example.com",
+        emailVerified: new Date(),
+      }]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectChain);
+
+    const res = await POST();
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Email is already verified");
+  });
+
+  it("sends verification email on success", async () => {
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe("Verification email sent");
+    expect(sendVerificationEmail).toHaveBeenCalledWith("test@example.com", expect.any(String));
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("DB connection failed");
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Something went wrong");
+  });
+});

--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { db } from "@/db";
+import { users, emailVerificationTokens } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
+import { sendVerificationEmail } from "@/lib/email";
+
+export async function POST() {
+  try {
+    const session = await auth();
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const { success } = rateLimit(`resend-verification:${session.user.id}`, {
+      maxRequests: 2,
+      windowMs: 60_000,
+    });
+    if (!success) {
+      return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        { status: 429 }
+      );
+    }
+
+    const [user] = await db
+      .select({ id: users.id, email: users.email, emailVerified: users.emailVerified })
+      .from(users)
+      .where(eq(users.id, session.user.id))
+      .limit(1);
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    if (user.emailVerified) {
+      return NextResponse.json(
+        { error: "Email is already verified" },
+        { status: 400 }
+      );
+    }
+
+    const rawToken = crypto.randomBytes(32).toString("hex");
+    const hashedToken = crypto.createHash("sha256").update(rawToken).digest("hex");
+
+    await db.insert(emailVerificationTokens).values({
+      userId: user.id,
+      token: hashedToken,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+    });
+
+    await sendVerificationEmail(user.email, rawToken);
+
+    return NextResponse.json(
+      { message: "Verification email sent" },
+      { status: 200 }
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Something went wrong" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/signup/route.test.ts
+++ b/src/app/api/auth/signup/route.test.ts
@@ -13,7 +13,12 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/db/schema", () => ({
-  users: { email: "email" },
+  users: { id: "id", email: "email" },
+  emailVerificationTokens: {},
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -50,7 +55,9 @@ describe("POST /api/auth/signup", () => {
     };
     (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectChain);
     (db.insert as ReturnType<typeof vi.fn>).mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined),
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "new-user-id" }]),
+      }),
     });
   });
 
@@ -99,8 +106,18 @@ describe("POST /api/auth/signup", () => {
   });
 
   it("creates user with hashed password and returns 201", async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined);
-    (db.insert as ReturnType<typeof vi.fn>).mockReturnValue({ values: valuesMock });
+    const returningMock = vi.fn().mockResolvedValue([{ id: "new-user-id" }]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const tokenValuesMock = vi.fn().mockResolvedValue(undefined);
+
+    let insertCallCount = 0;
+    (db.insert as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      insertCallCount++;
+      if (insertCallCount === 1) {
+        return { values: valuesMock };
+      }
+      return { values: tokenValuesMock };
+    });
 
     const res = await POST(
       makeRequest({
@@ -122,8 +139,18 @@ describe("POST /api/auth/signup", () => {
   });
 
   it("sets name to null if not provided", async () => {
-    const valuesMock = vi.fn().mockResolvedValue(undefined);
-    (db.insert as ReturnType<typeof vi.fn>).mockReturnValue({ values: valuesMock });
+    const returningMock = vi.fn().mockResolvedValue([{ id: "new-user-id" }]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const tokenValuesMock = vi.fn().mockResolvedValue(undefined);
+
+    let insertCallCount = 0;
+    (db.insert as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      insertCallCount++;
+      if (insertCallCount === 1) {
+        return { values: valuesMock };
+      }
+      return { values: tokenValuesMock };
+    });
 
     const res = await POST(
       makeRequest({ email: "no-name@example.com", password: "12345678" })

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
+import crypto from "crypto";
 import { db } from "@/db";
-import { users } from "@/db/schema";
+import { users, emailVerificationTokens } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import bcrypt from "bcryptjs";
 import { signupSchema } from "@/lib/validations";
 import { rateLimit } from "@/lib/rate-limit";
+import { sendVerificationEmail } from "@/lib/email";
 
 export async function POST(request: Request) {
   try {
@@ -42,11 +44,22 @@ export async function POST(request: Request) {
 
     const hashedPassword = await bcrypt.hash(password, 12);
 
-    await db.insert(users).values({
+    const [newUser] = await db.insert(users).values({
       name: name || null,
       email,
       password: hashedPassword,
+    }).returning({ id: users.id });
+
+    const rawToken = crypto.randomBytes(32).toString("hex");
+    const hashedToken = crypto.createHash("sha256").update(rawToken).digest("hex");
+
+    await db.insert(emailVerificationTokens).values({
+      userId: newUser.id,
+      token: hashedToken,
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
     });
+
+    await sendVerificationEmail(email, rawToken);
 
     return NextResponse.json(
       { message: "Account created successfully" },

--- a/src/app/api/auth/verify-email/route.test.ts
+++ b/src/app/api/auth/verify-email/route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: () => ({ success: true, remaining: 10 }),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  users: { id: "id", emailVerified: "emailVerified" },
+  emailVerificationTokens: { token: "token", usedAt: "usedAt", expiresAt: "expiresAt", id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+  and: vi.fn((...args: unknown[]) => args),
+  isNull: vi.fn((col) => ({ isNull: col })),
+  gt: vi.fn((col, val) => ({ gt: col, val })),
+}));
+
+import { POST } from "./route";
+import { db } from "@/db";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost:3000/api/auth/verify-email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/auth/verify-email", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectChain);
+
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue(updateChain);
+  });
+
+  it("returns 400 if token is missing", async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBeTruthy();
+  });
+
+  it("returns 400 if token is invalid or expired", async () => {
+    const res = await POST(makeRequest({ token: "invalid-token" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Invalid or expired");
+  });
+
+  it("verifies email and marks token as used on valid token", async () => {
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([{
+        id: "token-123",
+        userId: "user-456",
+        token: "hashed-token",
+        expiresAt: new Date(Date.now() + 86400000),
+        usedAt: null,
+      }]),
+    };
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(selectChain);
+
+    const setMock = vi.fn().mockReturnThis();
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue({ set: setMock, where: whereMock });
+
+    const res = await POST(makeRequest({ token: "valid-raw-token" }));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe("Email verified successfully");
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it("returns 500 on unexpected error", async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("DB connection failed");
+    });
+
+    const res = await POST(makeRequest({ token: "some-token" }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe("Something went wrong");
+  });
+});

--- a/src/app/api/auth/verify-email/route.ts
+++ b/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { db } from "@/db";
+import { users, emailVerificationTokens } from "@/db/schema";
+import { eq, and, isNull, gt } from "drizzle-orm";
+import { verifyEmailSchema } from "@/lib/validations";
+import { rateLimit } from "@/lib/rate-limit";
+
+export async function POST(request: Request) {
+  try {
+    const ip = request.headers.get("x-forwarded-for") ?? "unknown";
+    const { success } = rateLimit(`verify-email:${ip}`, { maxRequests: 5, windowMs: 60_000 });
+    if (!success) {
+      return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        { status: 429 }
+      );
+    }
+
+    const body = await request.json();
+    const parsed = verifyEmailSchema.safeParse(body);
+
+    if (!parsed.success) {
+      const firstError = parsed.error.issues[0]?.message || "Invalid input";
+      return NextResponse.json({ error: firstError }, { status: 400 });
+    }
+
+    const { token } = parsed.data;
+
+    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+
+    const [verificationToken] = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(
+        and(
+          eq(emailVerificationTokens.token, hashedToken),
+          isNull(emailVerificationTokens.usedAt),
+          gt(emailVerificationTokens.expiresAt, new Date())
+        )
+      )
+      .limit(1);
+
+    if (!verificationToken) {
+      return NextResponse.json(
+        { error: "Invalid or expired verification link. Please request a new one." },
+        { status: 400 }
+      );
+    }
+
+    await db
+      .update(users)
+      .set({ emailVerified: new Date() })
+      .where(eq(users.id, verificationToken.userId));
+
+    await db
+      .update(emailVerificationTokens)
+      .set({ usedAt: new Date() })
+      .where(eq(emailVerificationTokens.id, verificationToken.id));
+
+    return NextResponse.json(
+      { message: "Email verified successfully" },
+      { status: 200 }
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Something went wrong" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -47,7 +47,7 @@ export default function SignupPage() {
     if (result?.error) {
       router.push("/login");
     } else {
-      router.push("/dashboard");
+      router.push("/verify-email");
     }
   }
 

--- a/src/app/verify-email/confirm/page.tsx
+++ b/src/app/verify-email/confirm/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import AuthLayout from "@/components/auth-layout";
+
+function VerifyEmailConfirmForm() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const { update } = useSession();
+
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      setError("Invalid verification link. The token is missing.");
+      return;
+    }
+
+    async function verifyEmail() {
+      try {
+        const res = await fetch("/api/auth/verify-email", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          setStatus("error");
+          setError(data.error || "Something went wrong");
+          return;
+        }
+
+        await update();
+        setStatus("success");
+      } catch {
+        setStatus("error");
+        setError("Something went wrong");
+      }
+    }
+
+    verifyEmail();
+  }, [token, update]);
+
+  if (status === "loading") {
+    return (
+      <div className="text-center space-y-4">
+        <p className="text-gray-400">Verifying your email...</p>
+      </div>
+    );
+  }
+
+  if (status === "success") {
+    return (
+      <div className="text-center space-y-4">
+        <p className="text-green-400 bg-green-400/10 rounded-lg py-3 px-4">
+          Email verified successfully!
+        </p>
+        <Link
+          href="/dashboard"
+          className="inline-block bg-[#FC6200] hover:bg-[#FC6200]/90 text-white font-medium py-2 px-6 rounded-md"
+        >
+          Go to Dashboard
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center space-y-4">
+      <p className="text-red-400 bg-red-400/10 rounded-lg py-3 px-4">
+        {error}
+      </p>
+      <Link href="/verify-email" className="text-[#FC6200] hover:text-[#FC6200]/80 underline text-sm">
+        Resend verification email
+      </Link>
+    </div>
+  );
+}
+
+export default function VerifyEmailConfirmPage() {
+  return (
+    <AuthLayout
+      brandContent={
+        <p className="text-[#68DDDC] mt-4 text-center max-w-md text-lg">
+          Almost there — confirming your email address.
+        </p>
+      }
+    >
+      <h2 className="text-2xl font-bold text-white text-center">Email Verification</h2>
+      <p className="text-gray-400 text-center mt-2 mb-8">Confirming your email address</p>
+
+      <Suspense>
+        <VerifyEmailConfirmForm />
+      </Suspense>
+    </AuthLayout>
+  );
+}

--- a/src/app/verify-email/confirm/page.tsx
+++ b/src/app/verify-email/confirm/page.tsx
@@ -11,17 +11,14 @@ function VerifyEmailConfirmForm() {
   const token = searchParams.get("token");
   const { update } = useSession();
 
-  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (!token) {
-      setStatus("error");
-      setError("Invalid verification link. The token is missing.");
-      return;
-    }
+    if (!token) return;
 
     async function verifyEmail() {
+      setStatus("loading");
       try {
         const res = await fetch("/api/auth/verify-email", {
           method: "POST",
@@ -48,7 +45,20 @@ function VerifyEmailConfirmForm() {
     verifyEmail();
   }, [token, update]);
 
-  if (status === "loading") {
+  if (!token) {
+    return (
+      <div className="text-center space-y-4">
+        <p className="text-red-400 bg-red-400/10 rounded-lg py-3 px-4">
+          Invalid verification link. The token is missing.
+        </p>
+        <Link href="/verify-email" className="text-[#FC6200] hover:text-[#FC6200]/80 underline text-sm">
+          Resend verification email
+        </Link>
+      </div>
+    );
+  }
+
+  if (status === "idle" || status === "loading") {
     return (
       <div className="text-center space-y-4">
         <p className="text-gray-400">Verifying your email...</p>

--- a/src/app/verify-email/layout.tsx
+++ b/src/app/verify-email/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Verify Email",
+};
+
+export default function VerifyEmailLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { signOut } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+import AuthLayout from "@/components/auth-layout";
+
+export default function VerifyEmailPage() {
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  async function handleResend() {
+    setStatus("loading");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/auth/resend-verification", {
+        method: "POST",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error || "Something went wrong");
+        return;
+      }
+
+      setStatus("success");
+      setMessage("Verification email sent! Check your inbox.");
+    } catch {
+      setStatus("error");
+      setMessage("Something went wrong");
+    }
+  }
+
+  return (
+    <AuthLayout
+      brandContent={
+        <p className="text-[#68DDDC] mt-4 text-center max-w-md text-lg">
+          One last step — verify your email to access the ROI Calculator.
+        </p>
+      }
+    >
+      <div className="text-center space-y-6">
+        <h2 className="text-2xl font-bold text-white">Verify your email</h2>
+        <p className="text-gray-400">
+          We sent a verification link to your email address. Please check your inbox and click the link to verify your account.
+        </p>
+
+        {status === "success" && (
+          <p role="alert" aria-live="polite" className="text-sm text-green-400 bg-green-400/10 rounded-lg py-2">
+            {message}
+          </p>
+        )}
+
+        {status === "error" && (
+          <p role="alert" aria-live="polite" className="text-sm text-red-400 bg-red-400/10 rounded-lg py-2">
+            {message}
+          </p>
+        )}
+
+        <Button
+          onClick={handleResend}
+          disabled={status === "loading"}
+          className="w-full bg-[#FC6200] hover:bg-[#FC6200]/90 text-white h-11 text-base"
+        >
+          {status === "loading" ? "Sending..." : "Resend verification email"}
+        </Button>
+
+        <button
+          onClick={() => signOut({ callbackUrl: "/login" })}
+          className="text-sm text-gray-400 hover:text-gray-300 underline"
+        >
+          Sign out
+        </button>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,15 @@ export const passwordResetTokens = pgTable("password_reset_tokens", {
   createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
 });
 
+export const emailVerificationTokens = pgTable("email_verification_tokens", {
+  id: uuid("id").defaultRandom().primaryKey(),
+  userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  token: text("token").notNull().unique(),
+  expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
+  usedAt: timestamp("used_at", { mode: "date" }),
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+});
+
 export const scenarios = pgTable("scenarios", {
   id: uuid("id").defaultRandom().primaryKey(),
   userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -37,14 +37,26 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           id: user.id,
           name: user.name,
           email: user.email,
+          emailVerified: user.emailVerified,
         };
       },
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
       if (user) {
         token.id = user.id;
+        token.emailVerified = user.emailVerified ?? null;
+      }
+      if (trigger === "update" && token.id) {
+        const [dbUser] = await db
+          .select({ emailVerified: users.emailVerified })
+          .from(users)
+          .where(eq(users.id, token.id as string))
+          .limit(1);
+        if (dbUser) {
+          token.emailVerified = dbUser.emailVerified ?? null;
+        }
       }
       return token;
     },
@@ -52,6 +64,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (token.id) {
         session.user.id = token.id as string;
       }
+      session.user.emailVerified = (token.emailVerified as Date | null) ?? null;
       return session;
     },
   },

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -3,6 +3,32 @@ import { env } from "./env";
 
 const resend = new Resend(env.RESEND_API_KEY);
 
+export async function sendVerificationEmail(email: string, token: string) {
+  const verifyUrl = `${env.APP_URL}/verify-email/confirm?token=${token}`;
+
+  await resend.emails.send({
+    from: env.EMAIL_FROM,
+    to: email,
+    subject: "Verify your email address",
+    html: `
+      <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
+        <h1 style="color: #003350; font-size: 24px; margin-bottom: 16px;">Verify your email address</h1>
+        <p style="color: #4a5568; font-size: 16px; line-height: 1.5;">
+          Thanks for signing up! Please verify your email address by clicking the button below.
+        </p>
+        <div style="text-align: center; margin: 32px 0;">
+          <a href="${verifyUrl}" style="background-color: #FC6200; color: white; padding: 12px 32px; border-radius: 6px; text-decoration: none; font-weight: bold; display: inline-block;">
+            Verify email
+          </a>
+        </div>
+        <p style="color: #718096; font-size: 14px; line-height: 1.5;">
+          This link will expire in 24 hours. If you didn&apos;t create an account, you can safely ignore this email.
+        </p>
+      </div>
+    `,
+  });
+}
+
 export async function sendPasswordResetEmail(email: string, token: string) {
   const resetUrl = `${env.APP_URL}/reset-password?token=${token}`;
 

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -29,6 +29,10 @@ export const resetPasswordSchema = z.object({
     .max(128, "Password must be less than 128 characters"),
 });
 
+export const verifyEmailSchema = z.object({
+  token: z.string().min(1, "Token is required"),
+});
+
 export const passwordSchema = z.object({
   currentPassword: z.string().min(1, "Current password is required"),
   newPassword: z

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,16 +5,39 @@ export default auth((req) => {
   const pathname = req.nextUrl.pathname;
   const isOnDashboard = pathname.startsWith("/dashboard");
   const isOnAuth = pathname === "/login" || pathname === "/signup" || pathname === "/forgot-password" || pathname === "/reset-password";
+  const isOnVerifyEmail = pathname.startsWith("/verify-email");
+  const isEmailVerified = !!req.auth?.user?.emailVerified;
 
+  // Dashboard: require login + verified email
   if (isOnDashboard && !isLoggedIn) {
     return Response.redirect(new URL("/login", req.nextUrl));
   }
 
-  if (isOnAuth && isLoggedIn) {
+  if (isOnDashboard && isLoggedIn && !isEmailVerified) {
+    return Response.redirect(new URL("/verify-email", req.nextUrl));
+  }
+
+  // Auth pages: redirect verified users to dashboard
+  if (isOnAuth && isLoggedIn && isEmailVerified) {
+    return Response.redirect(new URL("/dashboard", req.nextUrl));
+  }
+
+  // Auth pages: redirect unverified users to verify-email (except login-related pages they may need)
+  if (isOnAuth && isLoggedIn && !isEmailVerified) {
+    return Response.redirect(new URL("/verify-email", req.nextUrl));
+  }
+
+  // Verify email pages: require login
+  if (isOnVerifyEmail && !isLoggedIn) {
+    return Response.redirect(new URL("/login", req.nextUrl));
+  }
+
+  // Verify email pages: redirect already-verified users to dashboard
+  if (isOnVerifyEmail && isLoggedIn && isEmailVerified) {
     return Response.redirect(new URL("/dashboard", req.nextUrl));
   }
 });
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/login", "/signup", "/forgot-password", "/reset-password"],
+  matcher: ["/dashboard/:path*", "/login", "/signup", "/forgot-password", "/reset-password", "/verify-email", "/verify-email/confirm"],
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,21 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+      emailVerified: Date | null;
+    } & DefaultSession["user"];
+  }
+
+  interface User {
+    emailVerified?: Date | null;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id?: string;
+    emailVerified?: Date | null;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #9

- **Email verification gate**: Users must verify their email before accessing `/dashboard`. Unverified users are redirected to `/verify-email`.
- **Verification flow**: On signup, a verification token is generated (256-bit, SHA-256 hashed in DB, 24hr expiry) and emailed to the user. Clicking the link verifies their account.
- **Resend support**: `/verify-email` page includes a "Resend verification email" button (rate limited to 2/min per user).
- **Session refresh**: After verification, the JWT is refreshed via NextAuth `update()` so the user can proceed to `/dashboard` without signing out.

## What changed

| Area | Files | Change |
|------|-------|--------|
| Database | `src/db/schema.ts`, `drizzle/0003_mean_loa.sql` | New `emailVerificationTokens` table |
| Types | `src/types/next-auth.d.ts` | Augment NextAuth Session/JWT/User with `emailVerified` |
| Auth | `src/lib/auth.ts` | Return `emailVerified` in authorize, handle `trigger=update` in JWT callback |
| Email | `src/lib/email.ts` | New `sendVerificationEmail()` function |
| Validations | `src/lib/validations.ts` | New `verifyEmailSchema` |
| Signup | `src/app/api/auth/signup/route.ts`, `src/app/signup/page.tsx` | Generate token + send email on signup, redirect to `/verify-email` |
| API | `src/app/api/auth/verify-email/route.ts` | Token verification endpoint (5 req/min rate limit) |
| API | `src/app/api/auth/resend-verification/route.ts` | Resend email endpoint (auth required, 2 req/min) |
| UI | `src/app/verify-email/page.tsx` | "Check your inbox" page with resend button |
| UI | `src/app/verify-email/confirm/page.tsx` | Token confirmation page (auto-submits on mount) |
| Middleware | `src/middleware.ts` | Email verification gate for `/dashboard`, routing for `/verify-email` |
| Tests | `route.test.ts` files | Tests for verify-email, resend-verification, updated signup tests |

## Test plan

- [x] `npx vitest run` — all 227 tests pass
- [x] Sign up with a new account → should redirect to `/verify-email`
- [x] Check email for verification link → click it → should verify and show "Go to Dashboard"
- [x] Try accessing `/dashboard` without verifying → should redirect to `/verify-email`
- [x] Click "Resend verification email" → should send a new email
- [x] Verify email → should be able to access `/dashboard`
- [x] Existing verified users should still access `/dashboard` normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)