### PR TITLE
Fix: Add SessionProvider to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import WebVitals from "@/components/web-vitals";
+import AuthSessionProvider from "@/components/session-provider";
 import "./globals.css";
 
 const geistMono = Geist_Mono({
@@ -42,8 +43,10 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark">
       <body className={`${geistMono.variable} antialiased`}>
-        <WebVitals />
-        {children}
+        <AuthSessionProvider>
+          <WebVitals />
+          {children}
+        </AuthSessionProvider>
       </body>
     </html>
   );

--- a/src/components/session-provider.tsx
+++ b/src/components/session-provider.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function AuthSessionProvider({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- The verify-email confirm page uses `useSession()` from `next-auth/react`, which requires a `SessionProvider` ancestor
- Without it, the deployed dev environment crashes with: `Cannot destructure property 'update' of 'useSession()' as it is undefined`
- Adds a client-side `AuthSessionProvider` wrapper component and includes it in the root layout

## Plan
This was a missing dependency from the email verification feature (PR #14). The `useSession()` hook in `/verify-email/confirm` needs `SessionProvider` in the React tree to function.

## Test plan
- [ ] Visit `/verify-email/confirm?token=test` — page should render without crashing
- [ ] Verify dashboard and other authenticated pages still work
- [ ] Verify the deployed dev environment no longer shows the "Something went wrong" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)