### PR TITLE
Fix email verification double-fire and stale JWT redirect

### DIFF
--- a/src/app/verify-email/confirm/page.tsx
+++ b/src/app/verify-email/confirm/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
@@ -10,12 +10,14 @@ function VerifyEmailConfirmForm() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   const { update } = useSession();
+  const hasVerified = useRef(false);
 
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (!token) return;
+    if (!token || hasVerified.current) return;
+    hasVerified.current = true;
 
     async function verifyEmail() {
       setStatus("loading");
@@ -36,6 +38,7 @@ function VerifyEmailConfirmForm() {
 
         await update();
         setStatus("success");
+        window.location.href = "/dashboard";
       } catch {
         setStatus("error");
         setError("Something went wrong");

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,18 @@
 import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
 
-export default auth((req) => {
+async function isEmailActuallyVerified(userId: string): Promise<boolean> {
+  const [user] = await db
+    .select({ emailVerified: users.emailVerified })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return !!user?.emailVerified;
+}
+
+export default auth(async (req) => {
   const isLoggedIn = !!req.auth;
   const pathname = req.nextUrl.pathname;
   const isOnDashboard = pathname.startsWith("/dashboard");
@@ -14,7 +26,11 @@ export default auth((req) => {
   }
 
   if (isOnDashboard && isLoggedIn && !isEmailVerified) {
-    return Response.redirect(new URL("/verify-email", req.nextUrl));
+    // JWT may be stale — check DB before redirecting
+    const verified = await isEmailActuallyVerified(req.auth!.user!.id!);
+    if (!verified) {
+      return Response.redirect(new URL("/verify-email", req.nextUrl));
+    }
   }
 
   // Auth pages: redirect verified users to dashboard
@@ -35,6 +51,14 @@ export default auth((req) => {
   // Verify email pages: redirect already-verified users to dashboard
   if (isOnVerifyEmail && isLoggedIn && isEmailVerified) {
     return Response.redirect(new URL("/dashboard", req.nextUrl));
+  }
+
+  // Verify email pages: check DB if JWT says unverified (may be stale after verification)
+  if (isOnVerifyEmail && isLoggedIn && !isEmailVerified) {
+    const verified = await isEmailActuallyVerified(req.auth!.user!.id!);
+    if (verified) {
+      return Response.redirect(new URL("/dashboard", req.nextUrl));
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- Fix confirm page `useEffect` firing multiple times, consuming the verification token and hitting rate limits
- Fix middleware redirecting verified users back to `/verify-email` due to stale JWT cookie by adding a DB fallback check

## Plan
These bugs were discovered during end-to-end testing of the email verification flow. The root causes were:

1. **Double-firing useEffect**: The `update` function from `useSession()` changed reference on re-renders, causing the `useEffect` to fire the verify API multiple times. Added a `useRef` guard to ensure single execution.

2. **Stale JWT in middleware**: After verification, `session.update()` didn't reliably refresh the JWT cookie before the redirect to `/dashboard`. The middleware now checks the database directly when the JWT says `emailVerified=null`, covering both `/dashboard` and `/verify-email` routes.

A longer-term fix is tracked in #18 (migrate to Clerk).

## Test plan
- [x] Verified login redirects unverified user to `/verify-email`
- [x] Resend button sends email via Resend
- [x] Clicking verification link verifies email and redirects to dashboard
- [x] Invalid/expired tokens show proper error message
- [x] Rate limiting still works
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)