### PR TITLE
Fix mobile hamburger overlapping header text

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,18 +10,18 @@ export default async function DashboardPage() {
   return (
     <>
       {/* Top bar */}
-      <header className="bg-gradient-to-r from-[#00273B] via-[#003350] to-[#00273B] border-b border-[#FC6200]/20 px-6 py-4 lg:px-8">
-        <div className="flex items-center gap-3 mb-0.5 pl-14 lg:pl-0">
+      <header className="bg-gradient-to-r from-[#00273B] via-[#003350] to-[#00273B] border-b border-[#FC6200]/20 pl-16 pr-6 py-4 lg:px-8">
+        <div className="flex items-center gap-3 mb-0.5">
           <div className="w-2 h-2 rounded-full bg-[#FC6200] animate-pulse" />
           <span className="text-xs font-semibold text-[#FC6200] uppercase tracking-widest">
             Pillar 1 · Embedded Commerce & Transaction Orchestration
           </span>
         </div>
-        <h1 className="text-xl font-bold text-white pl-14 lg:pl-0">
+        <h1 className="text-xl font-bold text-white">
           ISV Portfolio Analysis{" "}
           <span className="text-[#68DDDC]">· Card + ACH Multi-Rail Modeling</span>
         </h1>
-        <p className="text-xs text-gray-400 mt-0.5 pl-14 lg:pl-0">
+        <p className="text-xs text-gray-400 mt-0.5">
           {session?.user?.name ? `Logged in as ${session.user.name}` : ""}
         </p>
       </header>


### PR DESCRIPTION
## Summary
- Fix header text overlapping with the fixed hamburger menu button on mobile viewports

## Plan
The dashboard header had `pl-14` applied to individual child elements to clear the hamburger button, but this wasn't sufficient. Moved the left padding to the header container itself using `pl-16` (4rem) on mobile, switching to `lg:px-8` on desktop where the sidebar is visible.

## Test plan
- [x] Mobile (375x812): Header text clears hamburger button
- [x] Desktop (1280x720): Layout unaffected, sidebar displays normally
- [x] Hamburger menu opens/closes correctly on mobile

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)