### PR TITLE
Use shorter tab labels on mobile to show all 4 tabs

### DIFF
--- a/src/components/roi-calculator.render.test.tsx
+++ b/src/components/roi-calculator.render.test.tsx
@@ -18,6 +18,12 @@ vi.mock("recharts", () => ({
 
 import ROICalculator from "./roi-calculator";
 
+// Helper to find a tab button by its full label text (rendered inside a hidden span)
+function getTabButton(label: string) {
+  const span = screen.getByText(label);
+  return span.closest("button")!;
+}
+
 describe("ROICalculator", () => {
   it("renders without crashing", () => {
     render(<ROICalculator />);
@@ -34,15 +40,15 @@ describe("ROICalculator", () => {
 
   it("starts on the ISV Portfolio Input tab", () => {
     render(<ROICalculator />);
-    const tab = screen.getByText("ISV Portfolio Input");
+    const tab = getTabButton("ISV Portfolio Input");
     expect(tab.className).toContain("FC6200");
   });
 
   it("switches to ISV ROI Summary tab and renders content", async () => {
     const user = userEvent.setup();
     render(<ROICalculator />);
-    await user.click(screen.getByText("ISV ROI Summary"));
-    expect(screen.getByText("ISV ROI Summary").className).toContain("FC6200");
+    await user.click(getTabButton("ISV ROI Summary"));
+    expect(getTabButton("ISV ROI Summary").className).toContain("FC6200");
     // Summary tab should show annual savings KPIs
     expect(screen.getByText("Total Annual Savings")).toBeInTheDocument();
     expect(screen.getByText("Total w/ Residual Uplift")).toBeInTheDocument();
@@ -64,8 +70,8 @@ describe("ROICalculator", () => {
   it("switches to Merchant-Level ROI tab and renders content", async () => {
     const user = userEvent.setup();
     render(<ROICalculator />);
-    await user.click(screen.getByText("Merchant-Level ROI"));
-    expect(screen.getByText("Merchant-Level ROI").className).toContain("FC6200");
+    await user.click(getTabButton("Merchant-Level ROI"));
+    expect(getTabButton("Merchant-Level ROI").className).toContain("FC6200");
     // Should show per-merchant KPIs
     expect(screen.getByText("Annual Card Volume")).toBeInTheDocument();
     expect(screen.getByText("Annual ACH Volume")).toBeInTheDocument();
@@ -86,8 +92,8 @@ describe("ROICalculator", () => {
   it("switches to Cresora Assumptions tab and renders content", async () => {
     const user = userEvent.setup();
     render(<ROICalculator />);
-    await user.click(screen.getByText("Cresora Assumptions"));
-    expect(screen.getByText("Cresora Assumptions").className).toContain("FC6200");
+    await user.click(getTabButton("Cresora Assumptions"));
+    expect(getTabButton("Cresora Assumptions").className).toContain("FC6200");
     // Should show adjustment notice
     expect(screen.getByText(/Adjust these to match/)).toBeInTheDocument();
     // Should show assumption sections
@@ -179,7 +185,7 @@ describe("ROICalculator", () => {
     const select = screen.getByDisplayValue("Interchange-Plus (IC+)");
     await user.selectOptions(select, "flat");
     // Go to assumptions tab
-    await user.click(screen.getByText("Cresora Assumptions"));
+    await user.click(getTabButton("Cresora Assumptions"));
     expect(screen.getByText("Cresora Flat Rate")).toBeInTheDocument();
   });
 
@@ -188,14 +194,14 @@ describe("ROICalculator", () => {
     render(<ROICalculator />);
     const select = screen.getByDisplayValue("Interchange-Plus (IC+)");
     await user.selectOptions(select, "tiered");
-    await user.click(screen.getByText("Cresora Assumptions"));
+    await user.click(getTabButton("Cresora Assumptions"));
     expect(screen.getByText(/converts to IC\+/)).toBeInTheDocument();
   });
 
   it("shows exclusivity contract note on summary tab", async () => {
     const user = userEvent.setup();
     render(<ROICalculator />);
-    await user.click(screen.getByText("ISV ROI Summary"));
+    await user.click(getTabButton("ISV ROI Summary"));
     expect(screen.getByText(/Exclusivity clause restricts/)).toBeInTheDocument();
   });
 });

--- a/src/components/roi-calculator.tsx
+++ b/src/components/roi-calculator.tsx
@@ -651,23 +651,24 @@ export default function ROICalculator() {
   return (
     <div className="text-gray-100 font-sans">
       <div className="max-w-7xl mx-auto px-4 py-6">
-        <div className="flex gap-2 mb-8 border-b border-[#003350] overflow-x-auto" style={{ maskImage: "linear-gradient(to right, black 90%, transparent)", WebkitMaskImage: "linear-gradient(to right, black 90%, transparent)" }}>
+        <div className="flex gap-1 sm:gap-2 mb-8 border-b border-[#003350]">
           {[
-            { id: "isv", label: "ISV Portfolio Input" },
-            { id: "summary", label: "ISV ROI Summary" },
-            { id: "merchant", label: "Merchant-Level ROI" },
-            { id: "assumptions", label: "Cresora Assumptions" },
+            { id: "isv", label: "ISV Portfolio Input", shortLabel: "Portfolio" },
+            { id: "summary", label: "ISV ROI Summary", shortLabel: "ROI Summary" },
+            { id: "merchant", label: "Merchant-Level ROI", shortLabel: "Merchant" },
+            { id: "assumptions", label: "Cresora Assumptions", shortLabel: "Assumptions" },
           ].map((t) => (
             <button
               key={t.id}
               onClick={() => setTab(t.id)}
-              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-all -mb-px whitespace-nowrap ${
+              className={`px-2 sm:px-4 py-2.5 text-xs sm:text-sm font-medium border-b-2 transition-all -mb-px whitespace-nowrap ${
                 tab === t.id
                   ? "border-[#FC6200] text-[#FC6200]"
                   : "border-transparent text-gray-400 hover:text-gray-200"
               }`}
             >
-              {t.label}
+              <span className="sm:hidden">{t.shortLabel}</span>
+              <span className="hidden sm:inline">{t.label}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Abbreviate tab labels on mobile so all 4 tabs fit without horizontal scrolling
- Full labels preserved on larger screens

## Plan
On mobile (< 640px), tab labels are shortened:
- "ISV Portfolio Input" → "Portfolio"
- "ISV ROI Summary" → "ROI Summary"  
- "Merchant-Level ROI" → "Merchant"
- "Cresora Assumptions" → "Assumptions"

Also reduced gap (`gap-1`) and padding (`px-2`, `text-xs`) on mobile for a tighter fit. Removed the `overflow-x-auto` and mask gradient since scrolling is no longer needed.

## Test plan
- [x] Mobile (375x812): All 4 tabs visible with short labels
- [x] Desktop (1280x720): Full labels displayed normally
- [x] Tab switching works on both viewports

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)