### PR TITLE
Add CI/CD pipeline with environment promotion gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [dev, main]
+    branches: [dev, staging, main]
 
 jobs:
   ci:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,53 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  migrate:
+    name: Run Database Migrations
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx drizzle-kit migrate
+
+  health-check:
+    name: Post-Deploy Health Check
+    runs-on: ubuntu-latest
+    needs: [migrate]
+    environment: production
+
+    steps:
+      - name: Wait for Vercel deployment
+        run: sleep 90
+
+      - name: Health check
+        env:
+          PRODUCTION_URL: ${{ vars.PRODUCTION_URL }}
+        run: |
+          if [ -z "$PRODUCTION_URL" ]; then
+            echo "PRODUCTION_URL not set, skipping health check"
+            exit 0
+          fi
+          status=$(curl -s -o /dev/null -w "%{http_code}" "$PRODUCTION_URL/api/health")
+          if [ "$status" != "200" ]; then
+            echo "Health check failed with status $status"
+            echo "ROLLBACK: Revert the merge commit and redeploy"
+            exit 1
+          fi
+          echo "Health check passed"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,92 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  migrate:
+    name: Run Database Migrations
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npx drizzle-kit migrate
+
+  test:
+    name: Build, Lint & Test
+    runs-on: ubuntu-latest
+
+    env:
+      DATABASE_URL: postgresql://user:pass@localhost/fake?sslmode=require
+      BETTER_AUTH_SECRET: ci-dummy-secret-not-real-at-least-32chars
+      BETTER_AUTH_URL: http://localhost:3000
+      RESEND_API_KEY: re_ci_dummy_key_not_real
+      EMAIL_FROM: onboarding@resend.dev
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('package-lock.json') }}-
+            nextjs-${{ runner.os }}-
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+  health-check:
+    name: Post-Deploy Health Check
+    runs-on: ubuntu-latest
+    needs: [migrate, test]
+    environment: staging
+
+    steps:
+      - name: Wait for Vercel deployment
+        run: sleep 60
+
+      - name: Health check
+        env:
+          STAGING_URL: ${{ vars.STAGING_URL }}
+        run: |
+          if [ -z "$STAGING_URL" ]; then
+            echo "STAGING_URL not set, skipping health check"
+            exit 0
+          fi
+          status=$(curl -s -o /dev/null -w "%{http_code}" "$STAGING_URL/api/health")
+          if [ "$status" != "200" ]; then
+            echo "Health check failed with status $status"
+            exit 1
+          fi
+          echo "Health check passed"

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -1,0 +1,49 @@
+name: Promote to Production
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    name: Create PR from staging → main
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already exists for staging → main"
+            echo "https://github.com/${{ github.repository }}/pull/$existing"
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head staging \
+            --title "Promote staging → production" \
+            --body "$(cat <<'BODY'
+          ## Production Promotion
+
+          Automated PR to promote `staging` changes to `main` (production).
+
+          ### Checklist
+          - [ ] All staging checks pass (migrations, health check)
+          - [ ] Staging environment manually verified
+          - [ ] No known issues blocking release
+
+          Merging this PR will:
+          1. Run database migrations against the production database
+          2. Deploy to the production environment
+          3. Run a post-deploy health check
+
+          **This requires environment approval before the workflow runs.**
+          BODY
+          )"

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -1,0 +1,46 @@
+name: Promote to Staging
+
+on:
+  workflow_dispatch:
+
+jobs:
+  promote:
+    name: Create PR from dev → staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --base staging --head dev --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already exists for dev → staging"
+            echo "https://github.com/${{ github.repository }}/pull/$existing"
+            exit 0
+          fi
+
+          gh pr create \
+            --base staging \
+            --head dev \
+            --title "Promote dev → staging" \
+            --body "$(cat <<'BODY'
+          ## Promotion
+
+          Automated PR to promote `dev` changes to `staging`.
+
+          ### Checklist
+          - [ ] All CI checks pass on dev
+          - [ ] Changes reviewed and tested locally
+          - [ ] Database migrations are backwards-compatible
+
+          Merging this PR will:
+          1. Run database migrations against the staging database
+          2. Deploy to the staging environment
+          3. Run a post-deploy health check
+          BODY
+          )"

--- a/README.md
+++ b/README.md
@@ -118,11 +118,42 @@ In Docker, migrations run automatically before the app starts. If a migration fa
 
 There is no automated rollback. To revert a migration, write a new migration that undoes the changes.
 
-## What Happens When Code Is Committed
+## CI/CD Pipeline
 
-1. **Pull request created** → CI runs build, lint, and all tests. Next.js build cache speeds up repeat builds.
-2. **PR merged to `dev`** → Vercel deploys to preview environment.
-3. **Database migrations** are currently run manually before deploy. Automated migration pipeline is planned (#24).
+### Environment Flow
+
+```
+Feature Branch → dev (Development) → staging (Staging) → main (Production)
+```
+
+### What Happens When Code Is Committed
+
+1. **Pull request created** → CI runs build, lint, tests, and Docker build
+2. **PR merged to `dev`** → Vercel deploys to development preview
+3. **Promote to staging** → Run the "Promote to Staging" workflow in GitHub Actions (creates a PR from `dev` → `staging`). Merging runs migrations and deploys to staging.
+4. **Promote to production** → Run the "Promote to Production" workflow (creates a PR from `staging` → `main`). Requires environment approval. Merging runs migrations and deploys to production.
+
+### Promotion Commands
+
+Promotions are triggered via GitHub Actions workflows (Actions tab → workflow → Run workflow):
+
+- **Promote to Staging**: Creates a PR from `dev` → `staging`
+- **Promote to Production**: Creates a PR from `staging` → `main` (requires approval)
+
+### Database Migrations in Pipeline
+
+Migrations run automatically as part of each environment's deploy:
+- **Staging**: Runs `drizzle-kit migrate` against the staging database before deploy
+- **Production**: Runs `drizzle-kit migrate` against the production database before deploy
+
+Each environment uses its own `DATABASE_URL` stored as a GitHub Actions secret.
+
+### Rollback
+
+If a production deploy fails the health check:
+1. Revert the merge commit on `main`
+2. Push the revert — Vercel redeploys the previous version
+3. If a migration needs reverting, create a new migration that undoes the changes
 
 ## Health Check
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"dev\" ]; then exit 1; else exit 0; fi"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"staging\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"dev\" ]; then exit 1; else exit 0; fi"
 }


### PR DESCRIPTION
## Summary
- Add three-environment promotion flow: `dev` → `staging` → `main` (production)
- Automated database migrations before each deploy
- Post-deploy health checks
- Manual promotion workflows with approval gates for production

## Workflows

| Workflow | Trigger | What it does |
|----------|---------|-------------|
| `ci.yml` | PR to dev/staging/main | Build, lint, test, Docker build |
| `deploy-staging.yml` | Push to staging | Run migrations, deploy, health check |
| `deploy-production.yml` | Push to main | Run migrations (with approval), deploy, health check |
| `promote-to-staging.yml` | Manual | Creates PR from dev → staging |
| `promote-to-production.yml` | Manual | Creates PR from staging → main (requires approval) |

## Promotion flow
```
Feature Branch → PR → dev → promote → staging → promote → main
```

## Setup required after merge (repo settings, not code)
- [ ] Create `staging` branch from `dev`
- [ ] Create GitHub environments: `staging` and `production`
- [ ] Add `DATABASE_URL` secret to each environment
- [ ] Add `STAGING_URL` and `PRODUCTION_URL` variables to respective environments
- [ ] Configure production environment to require approval
- [ ] Configure Vercel to deploy staging branch to staging domain
- [ ] Add branch protection rules for `staging` and `main`

## Test plan
- [x] ESLint: 0 errors
- [x] Tests: 162/162 passed
- [x] Workflow YAML syntax validated

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)